### PR TITLE
Fix/permisson caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This document captures the history of significant changes to the wallet-toolbox repository. The git commit history contains the details but is unable to draw
 attention to changes that materially alter behavior or extend functionality.
 
+## wallet-toolbox 1.5.7
+
+- One-off authorizations are no longer cached, ensuring they can only be used once.
+
 ## wallet-toolbox 1.5.0
 
 - update to @bsv/sdk 1.6.8 and @bsv/auth-express-middleware 1.2.0 (Which include VarInt support for negative numbers, making it a breaking change)

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/wallet-toolbox-client",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Client only Wallet Storage",
   "main": "./out/src/index.client.js",
   "types": "./out/src/index.client.d.ts",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/wallet-toolbox-mobile",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Client only Wallet Storage",
   "main": "./out/src/index.mobile.js",
   "types": "./out/src/index.mobile.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/wallet-toolbox",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/wallet-toolbox",
-      "version": "1.5.6",
+      "version": "1.5.7",
       "license": "SEE LICENSE IN license.md",
       "dependencies": {
         "@bsv/auth-express-middleware": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/wallet-toolbox",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "BRC100 conforming wallet, wallet storage and wallet signer components",
   "main": "./out/src/index.js",
   "types": "./out/src/index.d.ts",

--- a/test/bsv-ts-sdk/LocalKVStore.test.ts
+++ b/test/bsv-ts-sdk/LocalKVStore.test.ts
@@ -53,18 +53,22 @@ describe('LocalKVStore tests', () => {
   })
 
   test('4 promise test', async () => {
-    jest.useFakeTimers();
-    let resolveNewLock: () => void = () => {};
-    const newLock = new Promise<void>(resolve => { resolveNewLock = resolve; });
-    const t = Date.now();
-    setTimeout(() => { resolveNewLock(); }, 1000);
-    jest.advanceTimersByTime(1000);
-    await newLock;
-    const elapsed = Date.now() - t;
-    logger(`Elapsed time: ${elapsed} ms`);
-    expect(elapsed).toBeGreaterThanOrEqual(1000);
-    jest.useRealTimers();
-  });
+    jest.useFakeTimers()
+    let resolveNewLock: () => void = () => {}
+    const newLock = new Promise<void>(resolve => {
+      resolveNewLock = resolve
+    })
+    const t = Date.now()
+    setTimeout(() => {
+      resolveNewLock()
+    }, 1000)
+    jest.advanceTimersByTime(1000)
+    await newLock
+    const elapsed = Date.now() - t
+    logger(`Elapsed time: ${elapsed} ms`)
+    expect(elapsed).toBeGreaterThanOrEqual(1000)
+    jest.useRealTimers()
+  })
 
   test('5 set x 4 get set x 4 get', async () => {
     for (const { storage, wallet } of ctxs) {


### PR DESCRIPTION
## Description of Changes

One-off authorizations are no longer cached, ensuring they can only be used once

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [x] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged