### PR TITLE
Group permission token creation

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/wallet-toolbox-client",
-  "version": "1.6.23",
+  "version": "1.6.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/wallet-toolbox-client",
-      "version": "1.6.23",
+      "version": "1.6.24",
       "license": "SEE LICENSE IN license.md",
       "dependencies": {
         "@bsv/sdk": "^1.7.3",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/wallet-toolbox-client",
-  "version": "1.6.23",
+  "version": "1.6.24",
   "description": "Client only Wallet Storage",
   "main": "./out/src/index.client.js",
   "types": "./out/src/index.client.d.ts",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/wallet-toolbox-mobile",
-  "version": "1.6.23",
+  "version": "1.6.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/wallet-toolbox-mobile",
-      "version": "1.6.23",
+      "version": "1.6.24",
       "license": "SEE LICENSE IN license.md",
       "dependencies": {
         "@bsv/sdk": "^1.7.3"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/wallet-toolbox-mobile",
-  "version": "1.6.23",
+  "version": "1.6.24",
   "description": "Client only Wallet Storage",
   "main": "./out/src/index.mobile.js",
   "types": "./out/src/index.mobile.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/wallet-toolbox",
-  "version": "1.6.23",
+  "version": "1.6.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/wallet-toolbox",
-      "version": "1.6.23",
+      "version": "1.6.24",
       "license": "SEE LICENSE IN license.md",
       "dependencies": {
         "@bsv/auth-express-middleware": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/wallet-toolbox",
-  "version": "1.6.23",
+  "version": "1.6.24",
   "description": "BRC100 conforming wallet, wallet storage and wallet signer components",
   "main": "./out/src/index.js",
   "types": "./out/src/index.d.ts",

--- a/src/WalletPermissionsManager.ts
+++ b/src/WalletPermissionsManager.ts
@@ -1693,9 +1693,8 @@ export class WalletPermissionsManager implements WalletInterface {
       {
         description: opts?.description ?? `Coalesce ${oldTokens.length} permission tokens`,
         inputs: oldTokens.map((t, i) => ({
-          // Keep the dot (.) outpoint format, as used elsewhere in your code
           outpoint: `${t.txid}.${t.outputIndex}`,
-          unlockingScriptLength: 74, // matches the PushDrop spend in your example
+          unlockingScriptLength: 74,
           inputDescription: `Consume permission token #${i + 1}`
         })),
         outputs: [
@@ -1720,7 +1719,7 @@ export class WalletPermissionsManager implements WalletInterface {
       throw new Error('Failed to create signable transaction')
     }
 
-    // 2) Sign each input using PushDrop.unlock with the same tuple you used to lock
+    // 2) Sign each input
     const partialTx = Transaction.fromAtomicBEEF(signableTransaction.tx)
     const pushdrop = new PushDrop(this.underlying)
     const unlocker = pushdrop.unlock(WalletPermissionsManager.PERM_TOKEN_ENCRYPTION_PROTOCOL, '1', 'self')

--- a/src/WalletPermissionsManager.ts
+++ b/src/WalletPermissionsManager.ts
@@ -658,7 +658,6 @@ export class WalletPermissionsManager implements WalletInterface {
       )
     }
     for (const p of params.granted.protocolPermissions || []) {
-      console.log('Granting protocol permission:', p)
       const token = await this.findProtocolToken(
         originator,
         false, // No privileged protocols allowed in groups for added security.

--- a/src/WalletPermissionsManager.ts
+++ b/src/WalletPermissionsManager.ts
@@ -656,17 +656,41 @@ export class WalletPermissionsManager implements WalletInterface {
       )
     }
     for (const p of params.granted.protocolPermissions || []) {
-      await this.createPermissionOnChain(
+
+      const token = await this.findProtocolToken(
+        originator,
+        false, // No privileged protocols allowed in groups for added security.
+        p.protocolID,
+        p.counterparty || 'self',
+        true
+      )
+      if (token) {
+      await this.renewPermissionOnChain(
+        token,
         {
           type: 'protocol',
           originator,
           privileged: false, // No privileged protocols allowed in groups for added security.
-          protocolID: p.protocolID,
-          counterparty: p.counterparty || 'self',
+          protocolID: p.protocolID, 
+          counterparty: p.counterparty || 'self', 
           reason: p.description
         },
         expiry
       )
+      }
+      else{
+        await this.createPermissionOnChain(
+          {
+            type: 'protocol',
+            originator,
+            privileged: false, // No privileged protocols allowed in groups for added security.
+            protocolID: p.protocolID,
+            counterparty: p.counterparty || 'self',
+            reason: p.description
+          },
+          expiry
+        )
+      }
     }
     for (const b of params.granted.basketAccess || []) {
       await this.createPermissionOnChain(


### PR DESCRIPTION
## Description of Changes

Added coalesceToken function for when renewing a permission token, along with a findAllProtocolTokens which finds all tokens that are the same details with the accepted difference of expiry

## Linked Issues / Tickets

Caused an issue of constantly asking for permissions and Group permissions constantly making new tokens due to only seeing the very top expired token always.

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [ ] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged